### PR TITLE
chore: enable ES module support

### DIFF
--- a/timeguard_vercel/package.json
+++ b/timeguard_vercel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "timeguard-vercel",
   "private": true,
+  "type": "module",
   "dependencies": {
     "pg": "^8.11.3"
   }


### PR DESCRIPTION
## Summary
- declare package as ES module to support modern import syntax

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689551cc74a083219375a0aafd788244