### PR TITLE
Restrict event source column values

### DIFF
--- a/timeguard_vercel/api/_db.js
+++ b/timeguard_vercel/api/_db.js
@@ -22,7 +22,7 @@ export async function initSchema() {
   CREATE TABLE IF NOT EXISTS events (
     id SERIAL PRIMARY KEY, employee_id INTEGER REFERENCES employees(id) ON DELETE CASCADE, device_id INTEGER REFERENCES devices(id) ON DELETE SET NULL,
     type TEXT CHECK (type IN ('check_in','check_out','break_start','break_end')) NOT NULL,
-    source TEXT CHECK (type IN ('check_in','check_out','break_start','break_end') OR source IN ('auto','manual','admin')) NOT NULL DEFAULT 'manual',
+    source TEXT CHECK (source IN ('auto','manual','admin')) NOT NULL DEFAULT 'manual',
     public_ip TEXT, created_at TIMESTAMPTZ DEFAULT now()
   );
   CREATE TABLE IF NOT EXISTS timesheets (


### PR DESCRIPTION
## Summary
- Limit `events.source` column to `auto`, `manual`, or `admin` with default `manual`

## Testing
- `node -e "import('./api/_db.js').then(m=>m.initSchema()).catch(e=>{console.error('init error',e); process.exit(1);})"` *(fails: connect ECONNREFUSED)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689551ce711c8321ad123bf8e7ebb1c4