### PR TITLE
Gate IP checks behind SKIP_GEOFENCE

### DIFF
--- a/timeguard_vercel/api/events/break-end.js
+++ b/timeguard_vercel/api/events/break-end.js
@@ -11,7 +11,7 @@ export default async function handler(req, res){
     const dev = await p.query('SELECT d.*, e.id as employee_id FROM devices d JOIN employees e ON e.id = d.employee_id WHERE device_uuid=$1', [device_uuid]);
     if (!dev.rowCount) return res.status(401).json({ error: 'invalid device' });
     const ip = clientIP(req);
-    if (CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
+    if (!CONFIG.SKIP_GEOFENCE && CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
     const ev = await p.query('INSERT INTO events (employee_id, device_id, type, source, public_ip) VALUES ($1,$2,$3,$4,$5) RETURNING *', [dev.rows[0].employee_id, dev.rows[0].id, 'break_end', source||'manual', ip]);
     // recompute timesheet
     const day = todayYMD();

--- a/timeguard_vercel/api/events/break-start.js
+++ b/timeguard_vercel/api/events/break-start.js
@@ -11,7 +11,7 @@ export default async function handler(req, res){
     const dev = await p.query('SELECT d.*, e.id as employee_id FROM devices d JOIN employees e ON e.id = d.employee_id WHERE device_uuid=$1', [device_uuid]);
     if (!dev.rowCount) return res.status(401).json({ error: 'invalid device' });
     const ip = clientIP(req);
-    if (CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
+    if (!CONFIG.SKIP_GEOFENCE && CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
     const ev = await p.query('INSERT INTO events (employee_id, device_id, type, source, public_ip) VALUES ($1,$2,$3,$4,$5) RETURNING *', [dev.rows[0].employee_id, dev.rows[0].id, 'break_start', source||'manual', ip]);
     // recompute timesheet
     const day = todayYMD();

--- a/timeguard_vercel/api/events/check-in.js
+++ b/timeguard_vercel/api/events/check-in.js
@@ -11,7 +11,7 @@ export default async function handler(req, res){
     const dev = await p.query('SELECT d.*, e.id as employee_id FROM devices d JOIN employees e ON e.id = d.employee_id WHERE device_uuid=$1', [device_uuid]);
     if (!dev.rowCount) return res.status(401).json({ error: 'invalid device' });
     const ip = clientIP(req);
-    if (CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
+    if (!CONFIG.SKIP_GEOFENCE && CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
     const ev = await p.query('INSERT INTO events (employee_id, device_id, type, source, public_ip) VALUES ($1,$2,$3,$4,$5) RETURNING *', [dev.rows[0].employee_id, dev.rows[0].id, 'check_in', source||'manual', ip]);
     // recompute timesheet
     const day = todayYMD();

--- a/timeguard_vercel/api/events/check-out.js
+++ b/timeguard_vercel/api/events/check-out.js
@@ -11,7 +11,7 @@ export default async function handler(req, res){
     const dev = await p.query('SELECT d.*, e.id as employee_id FROM devices d JOIN employees e ON e.id = d.employee_id WHERE device_uuid=$1', [device_uuid]);
     if (!dev.rowCount) return res.status(401).json({ error: 'invalid device' });
     const ip = clientIP(req);
-    if (CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
+    if (!CONFIG.SKIP_GEOFENCE && CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip)) return res.status(403).json({ error: `IP ${ip} not allowed` });
     const ev = await p.query('INSERT INTO events (employee_id, device_id, type, source, public_ip) VALUES ($1,$2,$3,$4,$5) RETURNING *', [dev.rows[0].employee_id, dev.rows[0].id, 'check_out', source||'manual', ip]);
     // recompute timesheet
     const day = todayYMD();


### PR DESCRIPTION
## Summary
- guard IP restriction logic so it only runs when geofencing is enabled via CONFIG.SKIP_GEOFENCE

## Testing
- `node --input-type=module -e "process.env.PUBLIC_IPS='1.1.1.1'; process.env.SKIP_GEOFENCE='false'; const {CONFIG}=await import('./timeguard_vercel/api/_helpers.js'); const ip='2.2.2.2'; console.log(!CONFIG.SKIP_GEOFENCE && CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip));"`
- `node --input-type=module -e "process.env.PUBLIC_IPS='1.1.1.1'; process.env.SKIP_GEOFENCE='true'; const {CONFIG}=await import('./timeguard_vercel/api/_helpers.js'); const ip='2.2.2.2'; console.log(!CONFIG.SKIP_GEOFENCE && CONFIG.PUBLIC_IPS.length>0 && !CONFIG.PUBLIC_IPS.includes(ip));"`
- `cd timeguard_vercel && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689551ce89448321af1b3cb5cc2666e5