### PR TITLE
Fix 404 on Vercel by enabling ESM and static web config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+
+# Optional: ignore local lock file
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "timeguard-vercel",
   "private": true,
+  "type": "module",
   "dependencies": {
     "pg": "^8.11.3"
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,27 +1,7 @@
 {
   "version": 2,
+  "public": "web",
   "builds": [
-    {
-      "src": "api/**/*.js",
-      "use": "@vercel/node"
-    },
-    {
-      "src": "web/**/*",
-      "use": "@vercel/static"
-    }
-  ],
-  "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/api/$1"
-    },
-    {
-      "src": "/",
-      "dest": "/web/index.html"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/web/$1"
-    }
+    { "src": "api/**/*.js", "use": "@vercel/node" }
   ]
 }


### PR DESCRIPTION
## Summary
- enable ES modules for serverless API functions
- serve `web` directory as public static site on Vercel
- ignore local dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "import('./api/_db.js').then(() => console.log('import ok')).catch(e => console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_689554a8d8e88321b348e7916df31909