### PR TITLE
Fix event source constraint

### DIFF
--- a/api/_db.js
+++ b/api/_db.js
@@ -22,7 +22,7 @@ export async function initSchema() {
   CREATE TABLE IF NOT EXISTS events (
     id SERIAL PRIMARY KEY, employee_id INTEGER REFERENCES employees(id) ON DELETE CASCADE, device_id INTEGER REFERENCES devices(id) ON DELETE SET NULL,
     type TEXT CHECK (type IN ('check_in','check_out','break_start','break_end')) NOT NULL,
-    source TEXT CHECK (type IN ('check_in','check_out','break_start','break_end') OR source IN ('auto','manual','admin')) NOT NULL DEFAULT 'manual',
+    source TEXT CHECK (source IN ('auto','manual','admin')) NOT NULL DEFAULT 'manual',
     public_ip TEXT, created_at TIMESTAMPTZ DEFAULT now()
   );
   CREATE TABLE IF NOT EXISTS timesheets (


### PR DESCRIPTION
## Summary
- ensure `events.source` column only accepts valid values

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68965509a5c88321ac25dac444bbaeb2