### PR TITLE
Restrict event source values

### DIFF
--- a/api/_db.js
+++ b/api/_db.js
@@ -22,7 +22,7 @@ export async function initSchema() {
   CREATE TABLE IF NOT EXISTS events (
     id SERIAL PRIMARY KEY, employee_id INTEGER REFERENCES employees(id) ON DELETE CASCADE, device_id INTEGER REFERENCES devices(id) ON DELETE SET NULL,
     type TEXT CHECK (type IN ('check_in','check_out','break_start','break_end')) NOT NULL,
-    source TEXT CHECK (type IN ('check_in','check_out','break_start','break_end') OR source IN ('auto','manual','admin')) NOT NULL DEFAULT 'manual',
+    source TEXT CHECK (source IN ('auto','manual','admin')) NOT NULL DEFAULT 'manual',
     public_ip TEXT, created_at TIMESTAMPTZ DEFAULT now()
   );
   CREATE TABLE IF NOT EXISTS timesheets (


### PR DESCRIPTION
## Summary
- validate `events.source` independently with `CHECK (source IN ('auto','manual','admin'))`

## Testing
- `DATABASE_URL=postgres://root:root@localhost/postgres node -e "import('./api/_db.js').then(m=>m.initSchema()).then(()=>console.log('done')).catch(e=>console.error(e))"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897643805ac83219898346b8d08a0c0