### PR TITLE
feat: log incoming API requests

### DIFF
--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -1,6 +1,7 @@
 import { getPool, initSchema } from '../_db.js';
 
 export default async function handler(req, res){
+  console.log('Incoming request', req.method, req.url, req.body);
   if (req.method !== 'POST') return res.status(405).end();
   await initSchema();
   const { name, phone, platform, device_uuid } = req.body || {};

--- a/api/devices/bind-mac.js
+++ b/api/devices/bind-mac.js
@@ -1,5 +1,6 @@
 import { getPool, initSchema } from '../_db.js';
 export default async function handler(req,res){
+  console.log('Incoming request', req.method, req.url, req.body);
   if (req.method !== 'POST') return res.status(405).end();
   await initSchema();
   const { device_uuid, wifi_mac } = req.body || {};

--- a/api/events/break-end.js
+++ b/api/events/break-end.js
@@ -2,6 +2,7 @@ import { getPool, initSchema } from '../../_db.js';
 import { clientIP, todayYMD, CONFIG } from '../../_helpers.js';
 
 export default async function handler(req, res){
+  console.log('Incoming request', req.method, req.url, req.body);
   if (req.method !== 'POST') return res.status(405).end();
   await initSchema();
   const p = getPool();

--- a/api/events/break-start.js
+++ b/api/events/break-start.js
@@ -2,6 +2,7 @@ import { getPool, initSchema } from '../../_db.js';
 import { clientIP, todayYMD, CONFIG } from '../../_helpers.js';
 
 export default async function handler(req, res){
+  console.log('Incoming request', req.method, req.url, req.body);
   if (req.method !== 'POST') return res.status(405).end();
   await initSchema();
   const p = getPool();

--- a/api/events/check-in.js
+++ b/api/events/check-in.js
@@ -2,6 +2,7 @@ import { getPool, initSchema } from '../../_db.js';
 import { clientIP, todayYMD, CONFIG } from '../../_helpers.js';
 
 export default async function handler(req, res){
+  console.log('Incoming request', req.method, req.url, req.body);
   if (req.method !== 'POST') return res.status(405).end();
   await initSchema();
   const p = getPool();

--- a/api/events/check-out.js
+++ b/api/events/check-out.js
@@ -2,6 +2,7 @@ import { getPool, initSchema } from '../../_db.js';
 import { clientIP, todayYMD, CONFIG } from '../../_helpers.js';
 
 export default async function handler(req, res){
+  console.log('Incoming request', req.method, req.url, req.body);
   if (req.method !== 'POST') return res.status(405).end();
   await initSchema();
   const p = getPool();

--- a/api/reports/monthly.js
+++ b/api/reports/monthly.js
@@ -1,5 +1,6 @@
 import { getPool, initSchema } from '../_db.js';
 export default async function handler(req,res){
+  console.log('Incoming request', req.method, req.url, req.method === 'GET' ? req.query : req.body);
   if (req.method !== 'GET') return res.status(405).end();
   await initSchema();
   const p = getPool();

--- a/api/router/webhook.js
+++ b/api/router/webhook.js
@@ -1,5 +1,6 @@
 import { getPool, initSchema } from '../_db.js';
 export default async function handler(req,res){
+  console.log('Incoming request', req.method, req.url, req.body);
   if (req.method !== 'POST') return res.status(405).end();
   await initSchema();
   const { secret, mac, type } = req.body || {};


### PR DESCRIPTION
## Summary
- log incoming requests in auth, event, report, device, and webhook handlers for easier debugging
- confirm client uses POST for /api/auth/register and /api/events/* endpoints
- ensure vercel.json routes API and static files appropriately for deployment

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68976439aa5483219141edea07404282